### PR TITLE
Grammatical fixes and typo in repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,29 @@
 
 # Zafiro icons 
-Minimalist icons created with the flat-desing technique, with washed out colors and always accompanied by white. the priority is simplicity
+Minimalist icons created with the flat-desing technique, utilizing washed out colors and always accompanied by white. The priority is simplicity.
 
-*if you find any missing application icon please report it to me,
-at the moment I only accept report of icons of missing applications,
-It is my knowledge that in the other categories there are some missing to add.*
+*If you find any missing application icons, please report them to me.
+At the moment I only accept reports of icons of missing applications,
+I am aware that icons in the other categories are still missing.*
 
-## donations
-you like my job and you want to help me, invite me to a cafe, I leave a league so you can donate through paypal if you wish
-
-[donate](https://www.paypal.me/zayronxio)
+## Donations
+If you like my job and you want to help me, invite me to a cafe. Here is a link so you can donate through PayPal if you wish: [donate](https://www.paypal.me/zayronxio)
 
 ### Download and testing
 
    - For testing you can clone the repository or download directly. Clone using your terminal.
 
    - In a Terminal run: 
-    `git clone https://github.com/zayronxio/zarifo-icons.git`
+    `git clone https://github.com/zayronxio/Zafiro-icons.git`
 
 ### Installing the icons
 
-   - Move the folder of icons to /home/.local/share/icons (in user mode) or /usr/share/icons (in root mode).
+   - Move the folder of icons to `~/.local/share/icons` (in user mode) or `/usr/share/icons` (in root mode).
 
    - The icon theme will be in the Setiings for select
-   
 
 
-## previews
+## Previews
 
 ![apps](https://raw.githubusercontent.com/zayronxio/Zafiro-icons/master/previews/apps.png)
 ![places](https://raw.githubusercontent.com/zayronxio/Zafiro-icons/master/previews/places.png)


### PR DESCRIPTION
* Fixed multiple grammatical issues throughout the page.
* Corrected all punctuation and capitalization.
* Changed `zarifo-icons.git` to `Zafiro-icons.git` in the installation instructions.