### PR TITLE
Variant a

### DIFF
--- a/index.theme
+++ b/index.theme
@@ -1,5 +1,5 @@
 [Icon Theme]
-Name=Zafiro-icons
+Name=Zafiro-icons-variat-A
 Comment=icon theme flat for gnome,xfce and lxde
 Comment[es]=tema de iconos planos y sobrios.
 Comment[zh_TW]=清醒和平面图标的主题

--- a/places/16/folder-documents.svg
+++ b/places/16/folder-documents.svg
@@ -10,7 +10,7 @@
    viewBox="0 0 16 16"
    version="1.1"
    id="svg14"
-   sodipodi:docname="folder-documents-symbolic.svg"
+   sodipodi:docname="folder-documents.svg"
    inkscape:version="0.92.3 (2405546, 2018-03-11)">
   <metadata
      id="metadata20">
@@ -1262,15 +1262,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1360"
-     inkscape:window-height="713"
+     inkscape:window-width="1920"
+     inkscape:window-height="1026"
      id="namedview16"
      showgrid="true"
      inkscape:zoom="10.429825"
-     inkscape:cx="8.5222265"
+     inkscape:cx="-11.228824"
      inkscape:cy="3.8026011"
      inkscape:window-x="0"
-     inkscape:window-y="27"
+     inkscape:window-y="28"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg14"
      showguides="false">
@@ -1284,11 +1284,11 @@
      transform="translate(-28,-1036.3622)"
      id="g2" />
   <path
-     style="fill:#6e7684;fill-opacity:1;stroke:none;stroke-width:0.1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:#eeeff1;fill-opacity:1;stroke:none;stroke-width:0.1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      d="M 2.5 4.5 L 2.5 14.5 L 14 14.5 L 14 4.5 L 11.25 4.5 L 11.25 10 C 11.25 11.123567 10.373975 11.792158 9.5078125 11.820312 C 9.0747312 11.83439 8.633528 11.696575 8.2988281 11.388672 C 7.9641282 11.080769 7.75 10.604971 7.75 10 L 7.75 5.5 C 7.75 5.0747421 7.9032319 4.7358191 8.1328125 4.5 L 2.5 4.5 z M 9.8671875 4.5 C 10.096768 4.7358191 10.25 5.0747421 10.25 5.5 L 10.25 9.5 C 10.25 9.7916667 10.176719 10.034557 10.042969 10.212891 C 9.9092185 10.391224 9.7083333 10.5 9.5 10.5 C 9.2916667 10.5 9.0907813 10.391224 8.9570312 10.212891 C 8.8232811 10.034557 8.75 9.7916667 8.75 9.5 L 8.75 6.5 L 9.25 6.5 L 9.25 9.5 C 9.25 9.7083333 9.3017186 9.8404427 9.3554688 9.9121094 C 9.4092186 9.983776 9.4583333 10 9.5 10 C 9.5416667 10 9.5907813 9.983776 9.6445312 9.9121094 C 9.6982813 9.8404427 9.75 9.7083333 9.75 9.5 L 9.75 5.5 C 9.75 4.8611111 9.375 4.625 9 4.625 C 8.625 4.625 8.25 4.8611111 8.25 5.5 L 8.25 10 C 8.25 10.490908 8.4108718 10.811922 8.6386719 11.021484 C 8.866472 11.231046 9.1752688 11.330615 9.4921875 11.320312 C 10.126025 11.299709 10.75 10.873157 10.75 10 L 10.75 4.5 L 9.8671875 4.5 z "
      id="rect4856" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#6e7684;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#eeeff1;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      d="m 2.5,1.5 v 13 h 2 V 3.5 H 13 v -2 z"
      id="path4858"
      inkscape:connector-curvature="0" />

--- a/places/16/folder-download.svg
+++ b/places/16/folder-download.svg
@@ -11,7 +11,7 @@
    version="1.1"
    id="svg14"
    sodipodi:docname="folder-download.svg"
-   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
   <metadata
      id="metadata20">
     <rdf:RDF>
@@ -668,15 +668,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1360"
-     inkscape:window-height="712"
+     inkscape:window-width="1920"
+     inkscape:window-height="1026"
      id="namedview16"
      showgrid="true"
      inkscape:zoom="20.85965"
-     inkscape:cx="5.8289583"
+     inkscape:cx="-4.0465669"
      inkscape:cy="5.2358351"
      inkscape:window-x="0"
-     inkscape:window-y="24"
+     inkscape:window-y="28"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg14">
     <inkscape:grid
@@ -689,7 +689,7 @@
      transform="translate(-28,-1036.3622)"
      id="g2" />
   <rect
-     style="opacity:1;fill:#6e7684;fill-opacity:0.68871593;fill-rule:nonzero;stroke:none;stroke-width:2.63493037;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     style="opacity:1;fill:#eeeff1;fill-opacity:0.68627453;fill-rule:nonzero;stroke:none;stroke-width:2.63493037;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect5088"
      width="7"
      height="5.5"
@@ -697,7 +697,7 @@
      y="1.5"
      ry="0" />
   <path
-     style="fill:#6e7684;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.37938213px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     style="fill:#eeeff1;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.37938213px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      d="m 1.5,8 h 13 L 8,14.5 Z"
      id="path5092"
      inkscape:connector-curvature="0"

--- a/places/16/folder-images.svg
+++ b/places/16/folder-images.svg
@@ -10,8 +10,8 @@
    viewBox="0 0 16 16"
    version="1.1"
    id="svg14"
-   sodipodi:docname="folder_images.svg"
-   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+   sodipodi:docname="folder-images.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
   <metadata
      id="metadata20">
     <rdf:RDF>
@@ -20,7 +20,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -1269,15 +1269,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1360"
-     inkscape:window-height="712"
+     inkscape:window-width="1920"
+     inkscape:window-height="1026"
      id="namedview16"
      showgrid="true"
      inkscape:zoom="10.429825"
-     inkscape:cx="8.7009952"
+     inkscape:cx="-11.050055"
      inkscape:cy="7.0654019"
      inkscape:window-x="0"
-     inkscape:window-y="24"
+     inkscape:window-y="28"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg14"
      showguides="false">
@@ -1291,19 +1291,19 @@
      transform="translate(-28,-1036.3622)"
      id="g2" />
   <path
-     style="fill:#6e7684;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     style="fill:#eeeff1;fill-opacity:0.68627453;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      d="m 1,14.5 4,-6 4,6 z"
      id="path1455"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cccc" />
   <path
-     style="fill:#6e7684;fill-opacity:0.52666662;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     style="fill:#eeeff1;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      d="M 4,14.5 9,10 15,14.5 Z"
      id="path1457"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cccc" />
   <circle
-     style="opacity:1;fill:#6e7684;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.85969281;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     style="opacity:1;fill:#eeeff1;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.85969281;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="path1459"
      cx="11.404121"
      cy="6.3288479"

--- a/places/16/folder-music.svg
+++ b/places/16/folder-music.svg
@@ -11,7 +11,7 @@
    version="1.1"
    id="svg14"
    sodipodi:docname="folder-music.svg"
-   inkscape:version="0.92.2pre0 (973e216, 2017-07-25)">
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
   <metadata
      id="metadata20">
     <rdf:RDF>
@@ -35,15 +35,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1360"
-     inkscape:window-height="740"
+     inkscape:window-width="1920"
+     inkscape:window-height="1026"
      id="namedview16"
      showgrid="true"
      inkscape:zoom="10.429825"
-     inkscape:cx="-0.98719741"
+     inkscape:cx="-20.738248"
      inkscape:cy="-3.341971"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="28"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg14">
     <inkscape:grid
@@ -54,7 +54,7 @@
      transform="translate(-28,-1036.3622)"
      id="g2" />
   <path
-     style="opacity:1;fill:#6e7684;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     style="opacity:1;fill:#eeeff1;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      d="M 5 2 C 4.446 2 4 2.446 4 3 L 4 4 L 4 10.126953 A 2.5 2.5 0 0 0 3.4667969 10.068359 A 2.5 2.5 0 0 0 0.96679688 12.568359 A 2.5 2.5 0 0 0 3.4667969 15.068359 A 2.5 2.5 0 0 0 5.9257812 13 L 6 13 L 6 5 L 12 5 L 12 10.113281 A 2.5 2.5 0 0 0 11.533203 10.068359 A 2.5 2.5 0 0 0 9.0332031 12.568359 A 2.5 2.5 0 0 0 11.533203 15.068359 A 2.5 2.5 0 0 0 13.994141 13 L 14 13 L 14 12.960938 A 2.5 2.5 0 0 0 14.033203 12.568359 A 2.5 2.5 0 0 0 14 12.158203 L 14 4 L 14 3 C 14 2.446 13.554 2 13 2 L 5 2 z "
      id="rect14" />
 </svg>

--- a/places/16/folder-templates.svg
+++ b/places/16/folder-templates.svg
@@ -11,7 +11,7 @@
    version="1.1"
    id="svg14"
    sodipodi:docname="folder-templates.svg"
-   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
   <metadata
      id="metadata20">
     <rdf:RDF>
@@ -20,7 +20,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -776,15 +776,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1360"
-     inkscape:window-height="712"
+     inkscape:window-width="1920"
+     inkscape:window-height="1026"
      id="namedview16"
      showgrid="true"
      inkscape:zoom="14.75"
-     inkscape:cx="16.043562"
+     inkscape:cx="2.0774603"
      inkscape:cy="4.9890884"
      inkscape:window-x="0"
-     inkscape:window-y="24"
+     inkscape:window-y="28"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg14"
      showguides="false">
@@ -801,5 +801,5 @@
      inkscape:connector-curvature="0"
      id="path1334-2"
      d="M 2.293854,1.8260166 V 13.935674 h 11.00878 L 10,9.5321622 V 11.733918 H 4.495611 V 6.5964876 l 2.201755,2.201756 V 6.5964876 Z M 8.459058,2.8537897 7.358181,5.0555455 8.018993,5.7163585 H 8.899122 L 9.559936,5.0555455 Z M 7.358181,5.935674 v 4.403512 L 8.018993,11 H 8.899122 L 9.559936,10.339186 V 5.935674 L 8.899122,6.5964876 H 8.238309 Z"
-     style="fill:#6e7684;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.73391861px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+     style="fill:#eeeff1;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.73391861px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
 </svg>

--- a/places/16/folder-videos.svg
+++ b/places/16/folder-videos.svg
@@ -14,7 +14,7 @@
    viewBox="0 0 4.2333332 4.2333335"
    version="1.1"
    id="svg8"
-   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
    sodipodi:docname="folder-videos.svg">
   <defs
      id="defs2" />
@@ -26,16 +26,16 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="31.678384"
-     inkscape:cx="9.1263303"
+     inkscape:cx="2.6234733"
      inkscape:cy="8.4908967"
      inkscape:document-units="mm"
      inkscape:current-layer="layer1"
      showgrid="true"
      units="px"
-     inkscape:window-width="1360"
-     inkscape:window-height="712"
+     inkscape:window-width="1920"
+     inkscape:window-height="1026"
      inkscape:window-x="0"
-     inkscape:window-y="24"
+     inkscape:window-y="28"
      inkscape:window-maximized="1">
     <inkscape:grid
        type="xygrid"
@@ -49,7 +49,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -59,7 +59,7 @@
      id="layer1"
      transform="translate(0,-292.76665)">
     <rect
-       style="opacity:1;fill:#6e7684;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.39687499;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       style="opacity:1;fill:#eeeff1;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.39687499;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="rect817"
        width="2.3812501"
        height="1.8520463"
@@ -67,7 +67,7 @@
        y="293.82498"
        ry="0.26458091" />
     <path
-       style="fill:#6e7684;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       style="fill:#eeeff1;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="m 3.175,294.35415 0.79375,-0.52917 v 1.85209 c 0.035518,0.0355 -0.6173611,-0.35278 -0.79375,-0.52917 z"
        id="path819"
        inkscape:connector-curvature="0"

--- a/places/16/folder.svg
+++ b/places/16/folder.svg
@@ -12,7 +12,7 @@
    version="1.1"
    id="svg14"
    sodipodi:docname="folder.svg"
-   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
   <metadata
      id="metadata20">
     <rdf:RDF>
@@ -1263,15 +1263,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1360"
-     inkscape:window-height="712"
+     inkscape:window-width="1920"
+     inkscape:window-height="1026"
      id="namedview16"
      showgrid="true"
      inkscape:zoom="14.75"
-     inkscape:cx="6.2981898"
+     inkscape:cx="-7.6679119"
      inkscape:cy="-0.90760925"
      inkscape:window-x="0"
-     inkscape:window-y="24"
+     inkscape:window-y="28"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg14"
      showguides="false">
@@ -1282,7 +1282,7 @@
        spacingy="0.5" />
   </sodipodi:namedview>
   <path
-     style="opacity:1;fill:#6e7684;fill-opacity:0.68871592;fill-rule:nonzero;stroke:none;stroke-width:11.33858299;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     style="opacity:1;fill:#dbdde1;fill-opacity:0.68871593;fill-rule:nonzero;stroke:none;stroke-width:11.33858299;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      d="m 1.701172,2.109375 c -0.277,0 -0.5,0.223 -0.5,0.5 v 1.5 2 c 0,-0.277 0.223,-0.5 0.5,-0.5 h 4.3574219 l 0.6425781,-1 c 0.1496604,-0.23309 0.223,-0.5 0.5,-0.5 h 7.5 c 0.277,0 0.5,0.223 0.5,0.5 v -0.5 c 0,-0.277 -0.223,-0.5 -0.5,-0.5 H 7.6191408 l -0.7910157,-1 c -0.1718403,-0.217255 -0.223,-0.5 -0.5,-0.5 z m -0.4746094,11.125 c 0.0075,0.02857 0.011267,0.05768 0.023438,0.08398 -0.010547,-0.02783 -0.021423,-0.05513 -0.023438,-0.08398 z m 0.1132813,0.216797 c 0.044892,0.0475 0.097623,0.0863 0.1582031,0.113281 -0.059981,-0.02746 -0.1133175,-0.06579 -0.1582031,-0.113281 z M 15,13.5 c -0.01871,0.0143 -0.03791,0.02748 -0.05859,0.03906 C 14.962314,13.527044 14.981178,13.514885 15,13.5 Z m -13.4999999,0.06641 c 0.061601,0.02702 0.1293718,0.04297 0.2011719,0.04297 -0.0718,0 -0.1401686,-0.01546 -0.2011719,-0.04297 z m 13.3730469,0.0078 c -0.05401,0.0198 -0.110882,0.03516 -0.171875,0.03516 0.06146,0 0.118176,-0.01486 0.171875,-0.03516 z"
      id="rect1168"
      inkscape:connector-curvature="0" />
@@ -1308,7 +1308,7 @@
     </g>
   </g>
   <path
-     style="opacity:1;fill:#6e7684;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:11.33858299;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     style="opacity:1;fill:#eeeff1;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:11.33858299;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      d="m 7.201172,4.109375 c -0.277,0 -0.3503396,0.26691 -0.5,0.5 l -0.6425781,1 H 1.701172 c -0.277,0 -0.5,0.223 -0.5,0.5 v 7 c 0,0.04435 0.014653,0.08412 0.025391,0.125 0.00543,0.07778 0.040182,0.154113 0.1132813,0.216797 0.091029,0.09632 0.2177279,0.158203 0.3613281,0.158203 h 0.042969 12.9570312 c 0.06925,0 0.135454,-0.01383 0.195312,-0.03906 0.119719,-0.05047 0.215157,-0.145907 0.265626,-0.265626 0.02523,-0.05986 0.03906,-0.126062 0.03906,-0.195312 v -7 -1.5 c 0,-0.277 -0.223,-0.5 -0.5,-0.5 z m 0.5039062,1 H 13.71875 c 0.277,0 0.5,0.223 0.5,0.5 v 1.5 4.96875 c 0,0.06925 -0.01383,0.135452 -0.03906,0.195312 -0.05047,0.119719 -0.145906,0.215155 -0.265625,0.265626 -0.05986,0.02523 -0.126063,0.03906 -0.195313,0.03906 H 2.701172 2.6582032 c -0.1436001,0 -0.2702991,-0.06188 -0.3613281,-0.158203 -0.073099,-0.06268 -0.1078512,-0.139017 -0.1132812,-0.216797 -0.010738,-0.04088 -0.025391,-0.08065 -0.025391,-0.125 v -4.96875 c 0,-0.277 0.223,-0.5 0.5,-0.5 h 3.9042969 l 0.6425781,-1 c 0.1496605,-0.23309 0.223,-0.5 0.5,-0.5 z"
      id="rect1155"
      inkscape:connector-curvature="0" />

--- a/places/16/user-desktop.svg
+++ b/places/16/user-desktop.svg
@@ -10,7 +10,7 @@
    viewBox="0 0 16 16"
    version="1.1"
    id="svg14"
-   sodipodi:docname="gnome-ccdesktop.svg"
+   sodipodi:docname="user-desktop.svg"
    inkscape:version="0.92.3 (2405546, 2018-03-11)">
   <metadata
      id="metadata20">
@@ -20,7 +20,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -776,15 +776,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1360"
-     inkscape:window-height="713"
+     inkscape:window-width="1920"
+     inkscape:window-height="1026"
      id="namedview16"
      showgrid="true"
      inkscape:zoom="10.429825"
-     inkscape:cx="7.970064"
+     inkscape:cx="-11.780986"
      inkscape:cy="6.117776"
      inkscape:window-x="0"
-     inkscape:window-y="27"
+     inkscape:window-y="28"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg14"
      showguides="false">
@@ -798,7 +798,7 @@
      transform="translate(-28,-1036.3622)"
      id="g2" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#6e7684;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.51181102;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#eeeff1;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.51181102;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      d="M 0.5 2 C 0.4551029 5.9188809 0.5869655 9.5816832 0.5 13.5 L 4.2460938 13.5 L 4.2460938 14 L 5.2460938 14 L 5.2460938 15 L 10.746094 15 L 10.746094 14 L 11.746094 14 L 11.746094 13.5 L 15.5 13.5 L 15.5 2 L 0.5 2 z M 2 3.5 L 14 3.5 L 14 12 L 2 12 L 2 3.5 z M 3.25 4.5 L 3.25 11 L 12.75 11 L 12.75 4.5 L 3.25 4.5 z M 8 5.25 L 12 5.25 L 12 7.75 L 8 7.75 L 8 10.25 L 4 10.25 L 4 7.75 L 8 7.75 L 8 5.25 z "
      id="rect215" />
 </svg>

--- a/places/16/user-home.svg
+++ b/places/16/user-home.svg
@@ -1263,15 +1263,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1360"
-     inkscape:window-height="713"
+     inkscape:window-width="1920"
+     inkscape:window-height="1026"
      id="namedview16"
      showgrid="true"
      inkscape:zoom="29.5"
-     inkscape:cx="2.3020389"
+     inkscape:cx="-4.6810119"
      inkscape:cy="6.4064898"
      inkscape:window-x="0"
-     inkscape:window-y="27"
+     inkscape:window-y="28"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg14"
      showguides="false">
@@ -1303,13 +1303,13 @@
     </g>
   </g>
   <path
-     style="fill:#6e7684;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:#eeeff1;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      d="M 7,14.5 H 2 v -6 h 12 v 6 H 9.5 v -4 H 7 Z"
      id="path1198"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="ccccccccc" />
   <path
-     style="fill:#6e7684;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     style="fill:#eeeff1;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      d="m 0.5,7.5 h 15 L 8,2 Z"
      id="path1203"
      inkscape:connector-curvature="0"

--- a/places/16/user-trash.svg
+++ b/places/16/user-trash.svg
@@ -11,7 +11,7 @@
    viewBox="0 0 16 16"
    version="1.1"
    id="svg14"
-   sodipodi:docname="user-trash-full.svg"
+   sodipodi:docname="user-trash.svg"
    inkscape:version="0.92.3 (2405546, 2018-03-11)">
   <metadata
      id="metadata20">
@@ -1263,15 +1263,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1360"
-     inkscape:window-height="713"
+     inkscape:window-width="1920"
+     inkscape:window-height="1026"
      id="namedview16"
      showgrid="true"
      inkscape:zoom="29.5"
-     inkscape:cx="1.019237"
+     inkscape:cx="-5.9638138"
      inkscape:cy="5.6993413"
      inkscape:window-x="0"
-     inkscape:window-y="27"
+     inkscape:window-y="28"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg14"
      showguides="false">
@@ -1303,24 +1303,24 @@
     </g>
   </g>
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#6e7684;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#eeeff1;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      d="M 1,3.5 V 5 H 15.5 V 3.4609375 Z"
      id="path1163"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="ccccc" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#6e7684;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.20000005;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#eeeff1;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.20000005;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      d="M 6.0019533,1.6113281 5.1503908,2.4628906 v 1.7480469 h 1.1992188 v -1.25 L 6.4980471,2.8125 h 3.5039059 l 0.148438,0.1484375 v 1.25 h 1.199218 V 2.4628906 L 10.498047,1.6113281 Z"
      id="path1165"
      inkscape:connector-curvature="0" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#6e7684;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.51181102;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#eeeff1;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.51181102;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      d="m 2.2441406,3.7441406 0.2711864,0.823656 v 9.5000004 c 0,0.682697 0.5731822,1.261002 1.2558594,1.255859 l 8.9999996,-0.0678 C 13.453864,15.250716 14.027045,14.682697 14.027045,14 V 4.5 3.7441406 H 12.244141 L 12.5,4.5 v 9 H 4 V 5 L 3.7558594,3.7441406 Z"
      id="rect352"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="ccssssccccccccc" />
   <rect
-     style="fill:#6e7684;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:#eeeff1;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="rect1157"
      width="1.5"
      height="7"
@@ -1332,9 +1332,9 @@
      height="7"
      width="1.5"
      id="rect1159"
-     style="fill:#6e7684;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+     style="fill:#eeeff1;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   <rect
-     style="fill:#6e7684;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:#eeeff1;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="rect1161"
      width="1.5"
      height="7"


### PR DESCRIPTION
Hi zayronxio,

Could you please add icons for urxvt and/or termite? I'm using xfce with Zafiro-Icons-Variant-A and when looking at the menu I see the default terminal icon. In the window button plugin for the xfce4-panel, I don't see those icons. I'm not too familiar with how icons work, but this look like it could be a matter of creating a system link for the application to the icon?

Thanks so much