### PR TITLE
Fix Todoist spelling mistake

### DIFF
--- a/apps/scalable/todoist.svg
+++ b/apps/scalable/todoist.svg
@@ -15,7 +15,7 @@
    version="1.1"
    id="svg5184"
    inkscape:version="0.92.1 r15371"
-   sodipodi:docname="todolist.svg">
+   sodipodi:docname="todoist.svg">
   <defs
      id="defs5178" />
   <sodipodi:namedview


### PR DESCRIPTION
Noticed that the Todoist icon was misspelled in #43. The committed icon was called "todolist", not "todoist" and thus wasn't displaying.

 