### PR TITLE
Fix icons in dark themes

### DIFF
--- a/index.theme
+++ b/index.theme
@@ -1,9 +1,9 @@
 [Icon Theme]
-Name=Zafiro-icons
+Name=Zafiro-icons-Dark
 Comment=icon theme flat for gnome,xfce and lxde
 Comment[es]=tema de iconos planos y sobrios.
 Comment[zh_TW]=清醒和平面图标的主题
-Inherits=Surfn,Numix,Numix-Circle-Light,Numix-Circle,breeze,gnome,hicolor
+Inherits=Surfn,Numix,Numix-Circle-Light,Numix-Circle,breeze-dark,gnome,hicolor
 
 PanelDefault=22
 PanelSizes=22


### PR DESCRIPTION
I love this icons theme, but this not work well in dark themes.
Changing the inherit to breeze-dark makes the contrast look better.