### PR TITLE
Fix font cache update error

### DIFF
--- a/apps/scalable/android-sdk (copia 1).svg
+++ b/apps/scalable/android-sdk (copia 1).svg
@@ -1,1 +1,0 @@
-android-studio.svg


### PR DESCRIPTION
Filename contains space, causing font cache update to fail.