### PR TITLE
directory list update

### DIFF
--- a/index.theme
+++ b/index.theme
@@ -3,13 +3,13 @@ Name=Zafiro-icons-Dark
 Comment=icon theme flat for gnome,xfce and lxde
 Comment[es]=tema de iconos planos y sobrios.
 Comment[zh_TW]=清醒和平面图标的主题
-Inherits=hicolor,Surfn,Numix,Numix-Circle,Numix-Circle,breeze-dark,gnome-dark
+Inherits=hicolor,Surfn,Numix,Numix-Circle,breeze-dark,gnome-dark
 
 PanelDefault=22
 PanelSizes=22
 
 # Directory list
-Directories=apps/scalable,apps/22,apps/48,apps/16,places/16-A,places/24,places/48,status/22,devices/48,devices/22,mimetypes/48,panel/22,panel/16,actions/16,actions/22-Dark,actions/48,categories/22-Dark,emblems/16,
+Directories=apps/scalable,apps/22,apps/48,apps/16,places/16-A,places/24,places/48,status/22,devices/48,devices/22,mimetypes/48,panel/22,panel/16,actions/16-Dark,actions/22-Dark,actions/48,categories/22-Dark,emblems/16,
 
 [apps/scalable]
 Size=48


### PR DESCRIPTION
change directory list for dark version of small action icons "actions/16-Dark"

`'index.theme' Line 12:`
Directories=apps/scalable,apps/22,apps/48,apps/16,places/16-A,places/24,places/48,status/22,devices/48,devices/22,mimetypes/48,panel/22,panel/16,actions/16-**Dark**,actions/22-Dark,actions/48,categories/22-Dark,emblems/16,

https://github.com/zayronxio/Zafiro-icons/issues/106, https://github.com/zayronxio/Zafiro-icons/issues/95 was not completely resolved. Sorry, I didn't notice earlier since it was showing visible icons (no darkness problem), but we are actually seeing _inherited_ icons mixed from other themes and not Zafiro's excellent icons if we don't fix this.