### PR TITLE
Add a symlink for the zathura icon

### DIFF
--- a/apps/scalable/org.pwmt.zathura.svg
+++ b/apps/scalable/org.pwmt.zathura.svg
@@ -1,0 +1,1 @@
+document-viewer.svg


### PR DESCRIPTION
The default desktop file of zathura uses the icon name `org.pwmt.zathura`. This PR adds a symlink for org.pwmt.zathura.svg.