### PR TITLE
Add Adwaita as a fallback theme

### DIFF
--- a/Dark/index.theme
+++ b/Dark/index.theme
@@ -3,7 +3,7 @@ Name=Zafiro-icons-Dark
 Comment=icon theme flat for gnome,xfce and lxde
 Comment[es]=tema de iconos planos y sobrios.
 Comment[zh_TW]=清醒和平面图标的主题
-Inherits=hicolor,Surfn,Numix,Numix-Circle,breeze-dark,gnome-dark
+Inherits=hicolor,Adwaita,Surfn,Numix,Numix-Circle,breeze-dark,gnome-dark
 
 PanelDefault=22
 PanelSizes=22

--- a/Light/index.theme
+++ b/Light/index.theme
@@ -3,7 +3,7 @@ Name=Zafiro-icons-Light
 Comment=icon theme flat for gnome,xfce and lxde
 Comment[es]=tema de iconos planos y sobrios.
 Comment[zh_TW]=清醒和平面图标的主题
-Inherits=Surfn,Numix,Numix-Circle-Light,Numix-Circle,breeze,gnome,hicolor
+Inherits=Surfn,Adwaita,Numix,Numix-Circle-Light,Numix-Circle,breeze,gnome,hicolor
 
 PanelDefault=22
 PanelSizes=22


### PR DESCRIPTION
There's a couple of missing icons on Gnome 43 when using this theme. This includes the Wifi icon in setting (fixes #121) as well as the Starred icons in Nautilus windows.

Falling back to Adwaita fixes this.

